### PR TITLE
fix: fix release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: build
-        run: yarn dev-lib tsc
+        run: yarn dev-lib build
 
       - name: release
         env:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5234,9 +5234,9 @@ typescript-eslint@^8.0.0:
     "@typescript-eslint/utils" "8.8.0"
 
 typescript@^5.0.2:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.3.tgz#e1b0a3c394190838a0b168e771b0ad56a0af0faa"
-  integrity sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
+  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
 
 "underscore@>= 1.1.6 < 1.14":
   version "1.13.6"


### PR DESCRIPTION
Next issue:
`yarn dev-lib tsc` was a mistake as it did not transpile into dist/
`yarn dev-lib build` failed due to unknown `--noCheck` parameter
so I also upgraded the typescript peer dependency to 5.6 which is shipped with support for the `--noCheck` option.